### PR TITLE
Bug fixes for Dish (2nd round)

### DIFF
--- a/src/main/java/commands/menu/AddDishCommand.java
+++ b/src/main/java/commands/menu/AddDishCommand.java
@@ -24,7 +24,6 @@ public class AddDishCommand extends Command {
     @Override
     public void execute(TextUi ui) {
         DishManager.addDishCommand(this.dishName, this.dishPrice, this.ingredientsList, ui);
-        Dish dish = new Dish(this.dishName, this.dishPrice, this.ingredientsList);
     }
 
     @Override

--- a/src/main/java/commands/menu/AddDishCommand.java
+++ b/src/main/java/commands/menu/AddDishCommand.java
@@ -1,7 +1,6 @@
 package commands.menu;
 
 import commands.Command;
-import entity.Dish;
 import manager.DishManager;
 import ui.TextUi;
 

--- a/src/main/java/common/Messages.java
+++ b/src/main/java/common/Messages.java
@@ -49,7 +49,7 @@ public class Messages {
     public static final String MESSAGE_FINISHED_LOADING = "Loading done. Starting Dinerdirector...\n";
     public static final String MESSAGE_STAFF_FOUND = "Here's the matching staff:";
     public static final String MESSAGE_STAFF_NOT_FOUND  ="There's no such staff in the staff list!";
-    public static final String MESSAGES_THE_LIST_OF_DISHES_IS_EMPTY = "(The list of dishes is empty).";
+    public static final String MESSAGES_THE_LIST_OF_DISHES_IS_EMPTY = "The list of dishes is empty.";
     /**
      * Errors for programs to print.
      */

--- a/src/main/java/common/Messages.java
+++ b/src/main/java/common/Messages.java
@@ -102,4 +102,7 @@ public class Messages {
     public static final String ERROR_STAFF_EXCESS_VIEW_PARAM = "Excessive parameter given to view staff command!";
     public static final String ERROR_PRICE_EXCEED_INTEGER_BOUNDS = "The maximum must not be greater than "
             + Integer.MAX_VALUE + " cents";
+    public static final String ERROR_DUPLICATE_DISH_NAME = "There is already a dish with the same name.";
+    public static final String ERROR_DISH_STORAGE_DUPLICATE_DISH_NAME = "There is already a dish with the same name." +
+            "\n%s\nSkipping line...\n";
 }

--- a/src/main/java/manager/DishManager.java
+++ b/src/main/java/manager/DishManager.java
@@ -94,4 +94,13 @@ public class DishManager {
                 + dish.getIngredientsList();
     }
 
+    public static boolean isInsideDishes(String name) {
+        for (Dish dish : dishes) {
+            if (dish.getDishName().equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/manager/DishManager.java
+++ b/src/main/java/manager/DishManager.java
@@ -22,7 +22,7 @@ public class DishManager {
     public static void addDishCommand(String name, int price, ArrayList<String> ingredients, TextUi ui) {
         Dish dish = new Dish(name, price, ingredients);
         dishes.add(dish);
-        ui.printMessage(DishManager.stringOfDishWithIndex(DishManager.getDishesSize(), dish));
+        ui.printMessage("Added dish: " + DishManager.stringOfDishWithIndex(DishManager.getDishesSize(), dish));
         try {
             DishStorage dishStorage = new DishStorage();
             dishStorage.writeToDishFile(dishes);
@@ -34,7 +34,7 @@ public class DishManager {
     public static void deleteDishCommand(int index, TextUi ui) {
         Dish selectedDish = dishes.get(index);
         dishes.remove(index);
-        ui.printMessage("deleted dish");
+        ui.printMessage("Deleted dish: " + DishManager.stringOfDishWithIndex(index + 1, selectedDish));
         try {
             DishStorage dishStorage = new DishStorage();
             dishStorage.writeToDishFile(dishes);

--- a/src/main/java/manager/DishManager.java
+++ b/src/main/java/manager/DishManager.java
@@ -62,7 +62,7 @@ public class DishManager {
         for (int i = 0; i < getDishesSize(); i++) {
             String[] words = dishes.get(i).getDishName().split(" ");
             for (String word : words) {
-                if (word.equals(stringToFind) || word.contains(stringToFind)) {
+                if (word.toLowerCase().contains(stringToFind.toLowerCase())) {
                     dishesMatchingKeyword.add(dishes.get(i));
                     indexes.add(i + 1);
                 }

--- a/src/main/java/utils/DishStorage.java
+++ b/src/main/java/utils/DishStorage.java
@@ -36,7 +36,7 @@ public class DishStorage {
             Pattern dishPattern = Pattern.compile(regex);
             Matcher parsedDishInput = dishPattern.matcher(text);
 
-            String name;
+            String name = null;
             Integer price;
             ArrayList<String> ingredients = new ArrayList<>();
             Dish dish = null;
@@ -49,6 +49,7 @@ public class DishStorage {
                     } catch (NumberFormatException e) {
                         throw new DinerDirectorException(Messages.ERROR_PRICE_EXCEED_INTEGER_BOUNDS);
                     }
+
                     String[] ingredientList = parsedDishInput.group(3).split(";");
                     for (String ingredient : ingredientList) {
                         String regexNumbers = "^[+-]?\\d+(?:\\.\\d+)?$";
@@ -58,12 +59,18 @@ public class DishStorage {
                             ingredients.add(ingredient);
                         }
                     }
+
+                    for (Dish currentDish : listOfDishes) {
+                        if (currentDish.getDishName().equals(name)) {
+                            throw new DinerDirectorException(Messages.ERROR_DISH_STORAGE_DUPLICATE_DISH_NAME);
+                        }
+                    }
                     dish = new Dish(name, price, ingredients);
                 } else {
                     throw new DinerDirectorException(Messages.ERROR_STORAGE_INVALID_READ_LINE);
                 }
             } catch (DinerDirectorException e) {
-                System.out.println(String.format(Messages.ERROR_STORAGE_INVALID_READ_LINE, text));
+                System.out.println(String.format(e.getMessage(), text));
             }
 
             if (dish != null) {

--- a/src/main/java/utils/DishStorage.java
+++ b/src/main/java/utils/DishStorage.java
@@ -51,7 +51,10 @@ public class DishStorage {
                     }
                     String[] ingredientList = parsedDishInput.group(3).split(";");
                     for (String ingredient : ingredientList) {
-                        if (!ingredient.isBlank()) {
+                        String regexNumbers = "^[+-]?\\d+(?:\\.\\d+)?$";
+                        Pattern pattern = Pattern.compile(regexNumbers);
+                        Matcher parsedIngredient = pattern.matcher(ingredient);
+                        if (!ingredient.isBlank() && !parsedIngredient.matches()) {
                             ingredients.add(ingredient);
                         }
                     }

--- a/src/main/java/utils/Parser.java
+++ b/src/main/java/utils/Parser.java
@@ -365,9 +365,9 @@ public class Parser {
         }
         return new FindDeadlineCommand((keyword.trim()));
     }
-    
+
     private Command prepareDeleteDishCommand(String userInputNoCommand) {
-    
+
         int indexToRemove = 0;
 
         try {
@@ -421,7 +421,10 @@ public class Parser {
                 }
                 String[] ingredientList = parsedDishInput.group(3).split(";");
                 for (String ingredient : ingredientList) {
-                    if (!ingredient.isBlank()) {
+                    String regexNumbers = "^[+-]?\\d+(?:\\.\\d+)?$";
+                    Pattern pattern = Pattern.compile(regexNumbers);
+                    Matcher parsedIngredient = pattern.matcher(ingredient);
+                    if (!ingredient.isBlank() && !parsedIngredient.matches()) {
                         ingredients.add(ingredient);
                     }
                 }

--- a/src/main/java/utils/Parser.java
+++ b/src/main/java/utils/Parser.java
@@ -24,6 +24,7 @@ import commands.Command;
 import common.Messages;
 import exceptions.DinerDirectorException;
 import entity.Deadline;
+import manager.DishManager;
 import manager.StaffManager;
 
 import java.util.ArrayList;
@@ -414,6 +415,9 @@ public class Parser {
         try {
             if (parsedDishInput.matches()) {
                 name = parsedDishInput.group(1);
+                if (DishManager.isInsideDishes(name)) {
+                    throw new DinerDirectorException(Messages.ERROR_DUPLICATE_DISH_NAME);
+                }
                 try {
                     price = Integer.parseInt(parsedDishInput.group(2));
                 } catch (NumberFormatException e) {
@@ -432,11 +436,12 @@ public class Parser {
                 throw new DinerDirectorException(Messages.ERROR_COMMAND_INVALID);
             }
         } catch (DinerDirectorException e) {
-            if (e.getMessage() != Messages.ERROR_COMMAND_INVALID) {
+            if (!e.getMessage().equals(Messages.ERROR_COMMAND_INVALID)) {
                 System.out.println(e.getMessage());
             }
             return new IncorrectCommand();
         }
+
         return new AddDishCommand(name, price, ingredients);
     }
 


### PR DESCRIPTION
* Remove redundant code left from shifting messages to DishManager.
* Print out the deleted dish instead of just "deleted dish".
* Update message used to print out when list of dishes is empty to match the rest of the features.
* Add regex checks to ensure numbers are not added as ingredients in both Parser and DishStorage. #146 
* Update find dish to be case insensitive #131 
* Update Add dish and DishStorage from adding dishes with duplicate names. #122 #141 
* Add new method in DishManager to check if the pending dish has a description matching any dishes in the list of dishes.
* Updates messages to be printed to the console when the user tries to add a dish with a duplicate name, and/or the dish_list text file contains dishes with duplicate names.